### PR TITLE
fix: support concurrent orchestration execution and fix live monitor …

### DIFF
--- a/agent/agent.js
+++ b/agent/agent.js
@@ -285,9 +285,14 @@ function writeFileAndWait(filePath, dataToWrite) {
 }
 
 function createEmptyFile(filePath) {
-  fs.writeFile(filePath, '', (err) => {
-    err ? debug(DEBUG_LEVEL.ERROR, `Error creating file: ${filePath}`) : debug(DEBUG_LEVEL.TRACE, `Empty file created: ${filePath}`);
-  });
+  try {
+    // Must be synchronous so the file is fully initialized before the script starts
+    // appending output. Async creation can race and truncate early log lines.
+    fs.writeFileSync(filePath, '', 'utf8');
+    debug(DEBUG_LEVEL.TRACE, `Empty file created: ${filePath}`);
+  } catch (err) {
+    debug(DEBUG_LEVEL.ERROR, `Error creating file: ${filePath} (${err.message})`);
+  }
 }
 
 function deleteFile(filePathToDelete) {

--- a/agentMessageProcessor.js
+++ b/agentMessageProcessor.js
@@ -2,6 +2,10 @@ const status_topic = 'orchelium/agent/status';
 const command_topic = 'orchelium/agent/command';
 const EventEmitter = require('events');
 const metricResultEmitter = new EventEmitter();
+
+// Serialize DB log writes per key so concurrent log chunks cannot overwrite
+// each other (for example, two first chunks both seeing NotFound).
+const logWriteQueues = {};
 const scriptTestManager = require('./scriptTestManager.js');
 
 /**
@@ -289,60 +293,46 @@ async function processMessage(topic, message,protocol) {
 
   //Update log record
   async function updateLogRecord(obj){
-    var key = getDbKey(obj,"log");
-    var value;
-   
-    var data;
-    var resp;
-    try{
-      data = await db.simpleGetData(key);
-    }
-    catch (error){
-      //If item doesn't exist add to DB
-      if (error.message.includes('NotFoundError')){
-        try {
-            logger.debug(`No Log record found - creating with key [${key}]`);
-            resp = await db.simplePutData(key,obj.data);
-            logger.debug(`Data created successfully for Key [${key}], Response [${resp}], Data \n${obj.data}`);
-            if (!obj.jobName || !obj.jobName.includes('Orchestration [')) {
-              emitScheduleLogUpdate(obj.jobName, obj.data, obj.executionId);
-            } else {
-              emitOrchestrationNodeLogUpdate(obj.jobName, obj.data);
-            }
-        }
-        catch (insertErr){
-          logger.error(`Unknown Issue creating new entry for key [${key}] to DB`);
-          logger.error(insertErr);
-          throw insertErr;
-        }
-      }
-      else{
-        logger.error(`Unknown Issue searching DB for key [${key}]`);
-        logger.error(error);
-        throw insertErr;
-      }
-    }
+    const key = getDbKey(obj, "log");
+    const previous = logWriteQueues[key] || Promise.resolve();
 
-    if(data!==undefined){
-      logger.debug('Retrieved data:', data);
-      data+=obj.data;
-      try{
-        logger.debug(``)
-        resp = await db.simplePutData(key,data);
-        logger.debug(`Data upadated successfully Key [${key}], Response [${resp}], Data \n${data}`);
-        if (!obj.jobName || !obj.jobName.includes('Orchestration [')) {
-          emitScheduleLogUpdate(obj.jobName, data, obj.executionId);
+    const next = previous.then(async () => {
+      const chunk = obj.data || '';
+      let existingData;
+
+      try {
+        existingData = await db.simpleGetData(key);
+      } catch (error) {
+        if (error.message && error.message.includes('NotFoundError')) {
+          existingData = '';
         } else {
-          emitOrchestrationNodeLogUpdate(obj.jobName, data);
+          logger.error(`Unknown Issue searching DB for key [${key}]`);
+          logger.error(error);
+          throw error;
         }
       }
-      catch (error){
+
+      const updatedData = `${existingData}${chunk}`;
+
+      try {
+        await db.simplePutData(key, updatedData);
+        logger.debug(`Data updated successfully key [${key}] bytes [${updatedData.length}]`);
+      } catch (error) {
         logger.error(`unable to add [${key}] to DB`);
         logger.error(error);
         throw error;
       }
-    }
 
+      if (!obj.jobName || !obj.jobName.includes('Orchestration [')) {
+        emitScheduleLogUpdate(obj.jobName, updatedData, obj.executionId);
+      } else {
+        emitOrchestrationNodeLogUpdate(obj.jobName, updatedData);
+      }
+    });
+
+    // Keep chain alive after failures so future chunks are not blocked forever.
+    logWriteQueues[key] = next.catch(() => {});
+    return next;
   }
 
   function emitOrchestrationNodeLogUpdate(jobName, logData) {

--- a/orchestrationEngine.js
+++ b/orchestrationEngine.js
@@ -18,6 +18,9 @@ const pendingExecutions = {};
 // This allows multiple concurrent executions of the same job without cross-talk
 const activeOrchestrationExecutions = {};  // jobId -> { executionIds: Set, latestExecutionId: string }
 
+// Serialize saveExecutionResult writes per jobId to prevent concurrent read-modify-write races
+const saveExecutionQueues = {};  // jobId -> Promise chain
+
 // Event emitter for script completion events
 const scriptCompletionEmitter = new EventEmitter();
 
@@ -322,7 +325,7 @@ async function executeJob(jobId, isManual = false, executionId = null, onNodeCom
               startTime: offlineCheckTime,
               endTime: offlineCheckTime
             };
-          } else if (agent.status !== 'online') {
+          } else if (agent.status === 'offline') {
             logger.warn(`[ORCHESTRATION] Agent [${agentId}] is offline (status: ${agent.status}) - skipping execution and continuing orchestration`);
             result = {
               exitCode: 1,
@@ -766,6 +769,16 @@ async function getExecutionHistory(jobId) {
  * @param {Object} executionLog - The execution log to save
  */
 async function saveExecutionResult(executionLog) {
+  const jobId = executionLog.jobId;
+
+  // Serialize writes per jobId to prevent concurrent read-modify-write races
+  const previous = saveExecutionQueues[jobId] || Promise.resolve();
+  const next = previous.then(() => _doSaveExecutionResult(executionLog));
+  saveExecutionQueues[jobId] = next.catch(() => {});  // Keep chain alive even on error
+  return next;
+}
+
+async function _doSaveExecutionResult(executionLog) {
   try {
     let executions = {};
     try {

--- a/server.js
+++ b/server.js
@@ -4408,13 +4408,14 @@ app.get('/orchestration/execution/details', User.isAuthenticated, asyncHandler(a
         }
 
         // Fetch live logs from database for in-progress execute nodes
+        // on every request so selected-node detail panels can stay current.
         const agents = require('./agents.js');
         for (const node of jobDef.nodes) {
           if (node.type === 'execute' && node.data && node.data.agent) {
             const agentId = node.data.agent;
             const agent = agents.getAgent(agentId);
-            if (agent && (!cachedExecution.scriptOutputs[node.id] || !cachedExecution.scriptOutputs[node.id].stdout)) {
-              // Node is executing or recently completed, try to fetch logs from database
+            if (agent) {
+              // Node is executing or recently completed, fetch latest logs from database
               const jobName = `Orchestration [${jobId}] Execution [${executionId}] Node [${node.id}]`;
               const logKey = `${agent.name}_${jobName}_${executionId}_log`;
               try {
@@ -4430,7 +4431,7 @@ app.get('/orchestration/execution/details', User.isAuthenticated, asyncHandler(a
                       status: 'in-progress'
                     };
                   }
-                  // Add/update the stdout with the live logs
+                  // Always update stdout with the latest persisted log snapshot.
                   cachedExecution.scriptOutputs[node.id].stdout = logContent;
                   logger.info(`[Orchestration Monitor] Fetched live logs for node [${node.id}] - ${logContent.length} bytes from key [${logKey}]`);
                 }

--- a/views/orchestrationMonitor.ejs
+++ b/views/orchestrationMonitor.ejs
@@ -853,6 +853,13 @@
 
               if (!selectedNode) {
                 renderOrchestrationInfo();
+              } else {
+                // Update only dynamic fields in-place to avoid full panel re-renders.
+                const updatedInPlace = updateSelectedNodeFieldsInPlace();
+                if (!updatedInPlace) {
+                  // Fallback only if panel structure is missing (for example after template changes).
+                  selectNode(selectedNode, { skipServerRefresh: true, preserveScroll: true });
+                }
               }
               
               updateSummaryPanel();
@@ -1040,12 +1047,15 @@
           }
           // If this node's panel is currently open, update the log textarea live
           if (selectedNode === nodeId) {
-            const logArea = document.querySelector('#detailsContent textarea');
+            const logArea = document.getElementById('selectedNodeOutputLog');
             if (logArea) {
               const wasAtBottom = logArea.scrollTop + logArea.clientHeight >= logArea.scrollHeight - 5;
               logArea.value = log;
               if (wasAtBottom) logArea.scrollTop = logArea.scrollHeight;
             }
+            // Show spinner while live streaming
+            const logSpinner = document.getElementById('logRefreshIndicator');
+            if (logSpinner) logSpinner.style.display = 'inline-block';
           }
         }
       });
@@ -1073,7 +1083,9 @@
         
         updateNodeState(nodeId, 'in-progress');
         if (selectedNode === nodeId) {
-          selectNode(nodeId);
+          if (!updateSelectedNodeFieldsInPlace()) {
+            selectNode(nodeId, { skipServerRefresh: true, preserveScroll: true });
+          }
         }
       });
 
@@ -1114,7 +1126,9 @@
         
         // If detail panel is open for this node, re-render it with updated status
         if (selectedNode === nodeId) {
-          selectNode(nodeId);
+          if (!updateSelectedNodeFieldsInPlace()) {
+            selectNode(nodeId, { skipServerRefresh: true, preserveScroll: true });
+          }
         } else if (!selectedNode) {
           renderOrchestrationInfo();
           updateSummaryPanel();
@@ -1815,14 +1829,16 @@
       selectNode(nodeId);
     };
 
-    async function selectNode(nodeId) {
+    async function selectNode(nodeId, options = {}) {
+      const skipServerRefresh = Boolean(options && options.skipServerRefresh);
+      const preserveScroll = Boolean(options && options.preserveScroll);
       selectedNode = nodeId;
       const node = executionData.nodes.find(n => n.id === nodeId);
 
       if (!node) return;
 
       // If execution is still in progress, refresh nodeScriptOutputs from server before showing panel
-      if (executionData.isInProgress) {
+      if (executionData.isInProgress && !skipServerRefresh) {
         try {
           const url = `/orchestration/execution/details?jobId=${encodeURIComponent(jobId)}&executionId=${encodeURIComponent(executionId)}`;
           const response = await fetch(url, { credentials: 'same-origin' });
@@ -1875,10 +1891,9 @@
       statusIcon = statusInfo.icon;
       statusColor = statusInfo.color;
 
+      let outputContent = '';
       let logHtml = '<p style="color: var(--text-muted); margin: 0;">No output captured</p>';
       if (nodeOutput && (nodeOutput.stdout || nodeOutput.stderr)) {
-        let outputContent = '';
-        
         // Add stdout if present
         if (nodeOutput.stdout) {
           outputContent += nodeOutput.stdout;
@@ -1893,7 +1908,9 @@
           }
         }
         
-        logHtml = `<textarea readonly rows="10" style="font-family: 'Courier New', monospace; width: 100%; height: auto;">${escapeHtml(outputContent)}</textarea>`;
+        logHtml = `<textarea id="selectedNodeOutputLog" readonly rows="10" style="font-family: 'Courier New', monospace; width: 100%; height: auto;">${escapeHtml(outputContent)}</textarea>`;
+      } else {
+        logHtml = '<textarea id="selectedNodeOutputLog" readonly rows="10" style="font-family: \'Courier New\', monospace; width: 100%; height: auto;"></textarea>';
       }
 
       // Format start time and duration from nodeMetrics
@@ -1997,13 +2014,21 @@
       const exitClass = displayExitCode === 0 ? 'exit-code-success' : (displayExitCode === 'N/A' ? '' : 'exit-code-failure');
       exitCodeHtml = `<div class="detail-item">
         <div class="detail-label">Exit Code</div>
-        <div class="detail-value ${exitClass}" style="font-weight: bold;">${displayExitCode}</div>
+        <div id="selectedNodeExitCode" class="detail-value ${exitClass}" style="font-weight: bold;">${displayExitCode}</div>
       </div>`;
 
       let errorHtml = '';
       if (statusInfo.state === 'failed' && node.errorMessage) {
         errorHtml = `<div class="error-message"><strong>Error:</strong> ${escapeHtml(node.errorMessage || 'Unknown error')}</div>`;
       }
+
+      const detailsSection = document.querySelector('.details-section');
+      const existingLogArea = document.querySelector('#detailsContent textarea');
+      const previousPanelScrollTop = detailsSection ? detailsSection.scrollTop : 0;
+      const previousLogScrollTop = existingLogArea ? existingLogArea.scrollTop : 0;
+      const wasLogNearBottom = existingLogArea
+        ? (existingLogArea.scrollTop + existingLogArea.clientHeight >= existingLogArea.scrollHeight - 5)
+        : false;
 
       const html = `
         <div class="detail-header">
@@ -2014,8 +2039,8 @@
           <div class="detail-item">
             <div class="detail-label">Status</div>
             <div class="detail-value" style="display: flex; align-items: center; gap: 6px;">
-              <span style="font-size: 1.2em; color: ${statusColor};">${statusIcon}</span>
-              <span>${statusText}</span>
+              <span id="selectedNodeStatusIcon" style="font-size: 1.2em; color: ${statusColor};">${statusIcon}</span>
+              <span id="selectedNodeStatusText">${statusText}</span>
             </div>
           </div>
           <div class="detail-item">
@@ -2041,7 +2066,10 @@
             <div class="detail-value">${parametersHtml}</div>
           </div>
           <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 8px;">
-            <div class="detail-label" style="margin-bottom: 0;">Output Log</div>
+            <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 0;">
+              <div class="detail-label" style="margin-bottom: 0;">Output Log</div>
+              <span id="logRefreshIndicator" class="refreshindicator refreshloader" style="display: ${statusInfo.state === 'in-progress' ? 'inline-block' : 'none'};"></span>
+            </div>
             ${logHtml}
           </div>
         </div>
@@ -2064,12 +2092,91 @@
         });
       }
       
-      // Reset scroll to top immediately after content update
-      const detailsSection = document.querySelector('.details-section');
-      detailsSection.scrollTop = 0;
+      // Preserve scroll positions during live refresh re-renders so users can watch logs.
+      if (detailsSection) {
+        if (preserveScroll) {
+          detailsSection.scrollTop = previousPanelScrollTop;
+        } else {
+          detailsSection.scrollTop = 0;
+        }
+      }
+
+      const newLogArea = document.querySelector('#detailsContent textarea');
+      if (preserveScroll && newLogArea) {
+        if (wasLogNearBottom) {
+          newLogArea.scrollTop = newLogArea.scrollHeight;
+        } else {
+          newLogArea.scrollTop = previousLogScrollTop;
+        }
+      }
       
       // Show details panel
       showDetailsPanel();
+    }
+
+    function updateSelectedNodeFieldsInPlace() {
+      if (!selectedNode || !executionData) {
+        return false;
+      }
+
+      const statusIconEl = document.getElementById('selectedNodeStatusIcon');
+      const statusTextEl = document.getElementById('selectedNodeStatusText');
+      const logArea = document.getElementById('selectedNodeOutputLog');
+      const exitCodeEl = document.getElementById('selectedNodeExitCode');
+      const logSpinner = document.getElementById('logRefreshIndicator');
+      if (!statusIconEl || !statusTextEl || !logArea || !exitCodeEl) {
+        return false;
+      }
+
+      const statusInfo = getNodeStatusInfo(selectedNode);
+      statusIconEl.textContent = statusInfo.icon;
+      statusIconEl.style.color = statusInfo.color;
+      statusTextEl.textContent = statusInfo.text;
+
+      if (logSpinner) {
+        logSpinner.style.display = statusInfo.state === 'in-progress' ? 'inline-block' : 'none';
+      }
+
+      let displayExitCode = 'N/A';
+      if (statusInfo.exitCode !== undefined) {
+        displayExitCode = statusInfo.exitCode;
+      }
+
+      const selectedNodeObj = executionData.nodes.find(n => n.id === selectedNode);
+      if (selectedNodeObj && selectedNodeObj.type === 'end-failure' && statusInfo.state === 'failed') {
+        displayExitCode = 9999;
+      }
+
+      exitCodeEl.textContent = displayExitCode;
+      exitCodeEl.classList.remove('exit-code-success', 'exit-code-failure');
+      if (displayExitCode === 0) {
+        exitCodeEl.classList.add('exit-code-success');
+      } else if (displayExitCode !== 'N/A') {
+        exitCodeEl.classList.add('exit-code-failure');
+      }
+
+      const nodeOutput = executionData.nodeScriptOutputs ? executionData.nodeScriptOutputs[selectedNode] : null;
+      let outputContent = '';
+      if (nodeOutput) {
+        if (nodeOutput.stdout) {
+          outputContent += nodeOutput.stdout;
+        }
+        if (nodeOutput.stderr) {
+          if (outputContent) {
+            outputContent += '\n\n--- STDERR ---\n' + nodeOutput.stderr;
+          } else {
+            outputContent += nodeOutput.stderr;
+          }
+        }
+      }
+
+      const wasAtBottom = logArea.scrollTop + logArea.clientHeight >= logArea.scrollHeight - 5;
+      logArea.value = outputContent;
+      if (wasAtBottom) {
+        logArea.scrollTop = logArea.scrollHeight;
+      }
+
+      return true;
     }
 
     function showDetailsPanel() {


### PR DESCRIPTION
…updates

Orchestration engine:
- Allow agents with status 'running' to accept new scripts (was incorrectly treating busy agents as offline, blocking concurrent runs)
- Serialize saveExecutionResult writes per jobId to prevent read-modify-write race that could silently drop concurrent execution history entries

Agent message processor:
- Serialize log DB writes per key via per-key promise chain to prevent concurrent first-chunk races causing missing initial log lines

Agent:
- Make log file initialization synchronous so the script process cannot start writing before the file is ready, preventing early output truncation under concurrent load

Server:
- Always refresh live node logs from DB on in-progress execution detail requests, not only when stdout is empty

Orchestration monitor:
- Replace full selected-node panel re-renders during live refresh with targeted in-place updates for status, output log and exit code
- Add stable element IDs (selectedNodeStatusIcon, selectedNodeStatusText, selectedNodeOutputLog, selectedNodeExitCode) for direct DOM targeting
- Preserve panel and log scroll positions during live updates; auto-follow bottom only when already pinned to bottom
- Route WebSocket node log events directly to selectedNodeOutputLog